### PR TITLE
Concertando erros que estavam dando no Cucumber

### DIFF
--- a/features/step_definitions/notifyInterestedPeople_step.rb
+++ b/features/step_definitions/notifyInterestedPeople_step.rb
@@ -11,8 +11,8 @@ E("preencho o campo {string} com {string}") do |string1, string2|
 	fill_in string1, with: string2
 end	
 
-Quando("pressiono {button}") do |button|
-    click_on(button)
+Quando("pressiono {string}") do |string|
+    click_on(string)
 end
 
 Então("eu devo ser redirecionado para {string}") do |string|
@@ -24,8 +24,8 @@ Dado("que eu estou na página {string}") do |string|
     visit "localhost:3000/#{string.downcase}"
 end
 
-Quando("pressiono {button}") do |button|
-    click_on(button)
+Quando("pressiono {string}") do |string|
+    click_on(string)
 end
 
 Então("eu devo ser redirecionado para {string}") do |string|
@@ -36,8 +36,8 @@ Quando("preencho o campo {string} com {string}") do |string1, string2|
 	fill_in string1, with: string2
 end	
 
-E("pressiono {button}") do |button|
-    click_on(button)
+E("pressiono {string}") do |string|
+    click_on(string)
 end
 
 Então("eu devo ver {string}") do |string|
@@ -49,8 +49,8 @@ Dado("que eu estou na página {string}") do |string|
     visit "localhost:3000/#{string.downcase}"
 end
 
-Quando("pressiono {button}") do |button|
-    click_on(button)
+Quando("pressiono {string}") do |string|
+    click_on(string)
 end
 
 Então("eu devo ser redirecionado para {string}") do |string|

--- a/features/step_definitions/showInterestActivity_steps.rb
+++ b/features/step_definitions/showInterestActivity_steps.rb
@@ -10,8 +10,8 @@ Given("I am on the {string} page") do |string|
     fill_in string
   end
   
-  When("I press {button}") do |button|
-    click_on(button)
+  When("I press {string}") do |string|
+    click_on(string)
   end
     
   Then("I should be on {string}") do |string|
@@ -19,32 +19,32 @@ Given("I am on the {string} page") do |string|
   end
   
   
-  When("I press {button}") do |button|
-     click_on(button)
+  When("I press {string}") do |string|
+     click_on(string)
    end
    
   Then("I should be on {string}") do |string|
     visit "localhost:3000/#{string.downcase}"
   end
   
-  When("I check {box}") do |box|
-     check(box)
+  When("I check {string}") do |string|
+     check(string)
    end
    
   Then("I should see on 'calendar' page only {string}") do |string|
     visit "localhost:3000/calendar//#{string.downcase}"
   end
   
-  When("I press {button}") do |button|
-     click_on(button)
+  When("I press {string}") do |string|
+     click_on(string)
    end
    
   Then("I should be on {string}") do |string|
     visit "localhost:3000/#{string.downcase}"
   end
   
-  When("I press {button}") do |button|
-     click_on(button)
+  When("I press {string}") do |string|
+     click_on(string)
    end
    
   Then("I should be on {string}") do |string|


### PR DESCRIPTION
Os steps do Cucubmer não reconhecem tipos de parâmetro 'button' ou 'box', por isso tava dando erro aqui.

Esse era o erro:
![image](https://user-images.githubusercontent.com/38587447/98712384-ffc90d00-2364-11eb-9858-6f879c23f936.png)

Mas ele deveria rodar assim por exemplo:

![image](https://user-images.githubusercontent.com/38587447/98712453-1707fa80-2365-11eb-88c0-1a82ab76e675.png)
